### PR TITLE
Export settings #51, take 2

### DIFF
--- a/app/Routes.js
+++ b/app/Routes.js
@@ -57,7 +57,12 @@ export default () => {
         <Route path={routes.SEARCH} component={SearchForm} />
         <Route path={routes.SELECTED} component={ActionList} />
         <Route
-          path={[routes.GENSETTINGS, routes.FILENAMETPLs, routes.ADVSETTINGS]}
+          path={[
+            routes.GENSETTINGS,
+            routes.FILENAMETPLs,
+            routes.ADVSETTINGS,
+            routes.EXPSETTINGS
+          ]}
           component={SettingsPage}
         />
         <Route path={routes.EXPORT} component={VideoExportPage} />

--- a/app/components/ActionList.js
+++ b/app/components/ActionList.js
@@ -20,7 +20,6 @@ import SearchResults from './SearchResults';
 import routes from '../constants/routes.json';
 import { EMPTY_SEARCHALERT } from '../constants/app';
 import ConfirmDelete from './ConfirmDelete';
-import VideoExportModal from './VideoExportModal';
 
 type Props = {
   sendResults: Object => void,
@@ -153,9 +152,6 @@ class ActionList extends Component<Props, State> {
           </Col>
           <Col md="2" className="pt-1">
             <ConfirmDelete onDelete={this.deleteAll} label="delete selected" />
-          </Col>
-          <Col className="pt-1">
-            <VideoExportModal airingList={actionList} label="export selected" />
           </Col>
         </Row>
         <SearchResults />

--- a/app/components/NamingTemplate.js
+++ b/app/components/NamingTemplate.js
@@ -3,9 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-// import * as fsPath from 'path';
-
-import * as slugify from 'slugify';
+import slugify from 'slugify';
 
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';

--- a/app/components/OpenDirecory.js
+++ b/app/components/OpenDirecory.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import fs from 'fs';
 import * as fsPath from 'path';
 
 import { Button } from 'react-bootstrap';
@@ -14,11 +13,7 @@ export default function OpenDirectory(prop: Props) {
   const { path } = prop;
 
   const openDir = () => {
-    if (fs.existsSync(path)) {
-      remote.shell.showItemInFolder(path);
-    } else {
-      remote.shell.showItemInFolder(fsPath.dirname(path));
-    }
+    remote.shell.openItem(fsPath.dirname(path));
   };
 
   return (

--- a/app/components/Recording.js
+++ b/app/components/Recording.js
@@ -129,7 +129,7 @@ class Recording extends Component<Props, State> {
                 &nbsp;
                 <TabloVideoPlayer airing={airing} />
                 &nbsp;
-                <VideoExportModal airingList={[airing]} />
+                <VideoExportModal airing={airing} />
                 &nbsp;
                 <ConfirmDelete airing={airing} />
               </Col>

--- a/app/components/Recording.js
+++ b/app/components/Recording.js
@@ -42,7 +42,6 @@ class Recording extends Component<Props, State> {
     this.checkboxRef = React.createRef();
 
     (this: any).toggleSelection = this.toggleSelection.bind(this);
-    (this: any).processVideo = this.processVideo.bind(this);
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -76,11 +75,6 @@ class Recording extends Component<Props, State> {
       remAiring(airing);
     }
   };
-
-  async processVideo() {
-    const { airing } = this.props;
-    await airing.processVideo();
-  }
 
   render() {
     const { airing, checked } = this.props;

--- a/app/components/RecordingSlim.js
+++ b/app/components/RecordingSlim.js
@@ -105,7 +105,7 @@ class RecordingSlim extends Component<Props> {
             </div>
             {withActions === ON ? (
               <div className="d-flex flex-row-reverse">
-                <VideoExportModal airingList={[airing]} />
+                <VideoExportModal airing={airing} />
                 &nbsp;
                 <TabloVideoPlayer airing={airing} />
               </div>

--- a/app/components/RelativeDate.js
+++ b/app/components/RelativeDate.js
@@ -12,14 +12,14 @@ export default function RelativeDate(props: Props) {
     date = Date.parse(date);
   }
 
-  if (!date) return <>Never</>;
+  if (!date) return <>Never</>; //
 
   let distance = formatDistanceToNow(date);
   if (distance === 'less than a minute') distance = '< 1 minute';
 
   return (
     <span
-      title={format(date, 'ccc M/d/yy @ h:m:s a')}
+      title={format(date, 'ccc M/d/yy @ h:mm:ss a')}
       style={{ textDecoration: 'underline', textDecorationStyle: 'dotted' }}
     >
       {distance} {term}

--- a/app/components/SettingsExport.js
+++ b/app/components/SettingsExport.js
@@ -60,7 +60,7 @@ class SettingsExport extends Component<Props, State> {
     return (
       <div>
         <Alert size="sm" variant="light" className="p-1 pl-3">
-          What should be done if the file already exists?
+          What should be done if a file already exists?
         </Alert>
         <Row className="mt-3">
           <Col md="6">

--- a/app/components/SettingsExport.js
+++ b/app/components/SettingsExport.js
@@ -1,0 +1,134 @@
+// @flow
+import React, { Component } from 'react';
+
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { Row, Col, Alert } from 'react-bootstrap';
+import * as FlashActions from '../actions/flash';
+import type { FlashRecordType } from '../reducers/types';
+
+import Checkbox, { CHECKBOX_OFF, CHECKBOX_ON } from './Checkbox';
+import getConfig, { setConfigItem } from '../utils/config';
+import {
+  DUPE_INC,
+  DUPE_OVERWRITE,
+  DUPE_SKIP,
+  DUPE_ADDID
+} from '../constants/app';
+
+type Props = { sendFlash: (message: FlashRecordType) => void };
+
+type State = { actionOnDuplicate: string };
+
+class SettingsExport extends Component<Props, State> {
+  props: Props;
+
+  constructor() {
+    super();
+    this.state = { actionOnDuplicate: getConfig().actionOnDuplicate };
+  }
+
+  setConfigAndState = (obj: any) => {
+    const { sendFlash } = this.props;
+    setConfigItem(obj);
+    this.setState(obj);
+    sendFlash({
+      message: `Default set to ${obj.actionOnDuplicate.toLowerCase()}`
+    });
+  };
+
+  toggleInc = () => {
+    this.setConfigAndState({ actionOnDuplicate: DUPE_INC });
+  };
+
+  toggleOverwrite = () => {
+    this.setConfigAndState({ actionOnDuplicate: DUPE_OVERWRITE });
+  };
+
+  toggleSkip = () => {
+    this.setConfigAndState({ actionOnDuplicate: DUPE_SKIP });
+  };
+
+  toggleAddId = () => {
+    this.setConfigAndState({ actionOnDuplicate: DUPE_ADDID });
+  };
+
+  render() {
+    const { actionOnDuplicate } = this.state;
+
+    return (
+      <div>
+        <Alert size="sm" variant="light" className="p-1 pl-3">
+          What should be done if the file already exists?
+        </Alert>
+        <Row className="mt-3">
+          <Col md="6">
+            <Checkbox
+              handleChange={this.toggleInc}
+              checked={
+                actionOnDuplicate === DUPE_INC ? CHECKBOX_ON : CHECKBOX_OFF
+              }
+              label="Increment"
+            />
+            <div className="pl-4 smallerish">
+              This will add <code>-#</code> to the filename...
+              <code>test.mp4</code>, <code>test-1.mp4</code>,
+              <code>test-2.mp4</code>, ...
+            </div>
+          </Col>
+          <Col md="6">
+            <Checkbox
+              handleChange={this.toggleOverwrite}
+              checked={
+                actionOnDuplicate === DUPE_OVERWRITE
+                  ? CHECKBOX_ON
+                  : CHECKBOX_OFF
+              }
+              label="Overwrite"
+            />
+            <div className="pl-4 smallerish">Overwrite it.</div>
+          </Col>
+        </Row>
+        <Row className="mt-2">
+          <Col md="6">
+            <Checkbox
+              handleChange={this.toggleAddId}
+              checked={
+                actionOnDuplicate === DUPE_ADDID ? CHECKBOX_ON : CHECKBOX_OFF
+              }
+              label="Add object_id"
+            />
+            <div className="pl-4 smallerish">
+              This will add <code>-X</code> where the X = the Tablo device
+              object_id to the filename...
+              <code>test.mp4</code>, <code>test-902732.mp4</code>,
+              <code>test-902735.mp4.mp4</code>, ...
+            </div>
+          </Col>
+          <Col md="6">
+            <Checkbox
+              handleChange={this.toggleSkip}
+              checked={
+                actionOnDuplicate === DUPE_SKIP ? CHECKBOX_ON : CHECKBOX_OFF
+              }
+              label="Skip"
+            />
+            <div className="pl-4 smallerish">
+              Ignore the recording and don&apos;t export it.
+            </div>
+          </Col>
+        </Row>
+      </div>
+    );
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return bindActionCreators(FlashActions, dispatch);
+};
+
+export default connect<*, *, *, *, *, *>(
+  null,
+  mapDispatchToProps
+)(SettingsExport);

--- a/app/components/SportDetails.js
+++ b/app/components/SportDetails.js
@@ -129,7 +129,7 @@ class SportDetails extends Component<Props, State> {
                 &nbsp;
                 <TabloVideoPlayer airing={event} />
                 &nbsp;
-                <VideoExportModal airingList={[event]} />
+                <VideoExportModal airing={event} />
                 <Button
                   size="xs"
                   className="ml-3 mr-2"

--- a/app/components/VideoExport.js
+++ b/app/components/VideoExport.js
@@ -18,6 +18,7 @@ import {
 } from '../utils/utils';
 import Airing from '../utils/Airing';
 import { CHECKBOX_OFF, CHECKBOX_ON } from './Checkbox';
+import getConfig from '../utils/config';
 
 type Props = {
   airingList: Array<Airing>,
@@ -28,7 +29,12 @@ type Props = {
   bulkRemExportRecord: (Array<ExportRecordType>) => void
 };
 
-type State = { exportState: number, atOnce: number, deleteOnFinish: number };
+type State = {
+  exportState: number,
+  atOnce: number,
+  deleteOnFinish: number,
+  actionOnDuplicate: string
+};
 
 const VideoExport = (WrappedComponent: any) => {
   // $FlowFixMe wtf typing
@@ -46,7 +52,8 @@ const VideoExport = (WrappedComponent: any) => {
       this.state = {
         exportState: EXP_WAITING,
         atOnce: 1,
-        deleteOnFinish: CHECKBOX_OFF
+        deleteOnFinish: CHECKBOX_OFF,
+        actionOnDuplicate: getConfig().actionOnDuplicate
       };
 
       this.shouldCancel = false;
@@ -66,11 +73,11 @@ const VideoExport = (WrappedComponent: any) => {
 
     processVideo = async () => {
       const { exportList } = this.props;
-      const { exportState, atOnce } = this.state;
+      const { atOnce, actionOnDuplicate } = this.state;
 
       global.EXPORTING = true;
 
-      if (exportState === EXP_DONE) return;
+      // if (exportState === EXP_DONE) return;
       await this.setState({ exportState: EXP_WORKING });
 
       const actions = [];
@@ -78,7 +85,10 @@ const VideoExport = (WrappedComponent: any) => {
       exportList.forEach(rec => {
         actions.push(() => {
           if (this.shouldCancel === false)
-            return rec.airing.processVideo(this.updateProgress);
+            return rec.airing.processVideo(
+              actionOnDuplicate,
+              this.updateProgress
+            );
         });
       });
 
@@ -184,20 +194,31 @@ const VideoExport = (WrappedComponent: any) => {
       });
     };
 
+    setActionOnDuplicate = (event: SyntheticEvent<HTMLInputElement>) => {
+      this.setState({ actionOnDuplicate: event.currentTarget.value });
+    };
+
     render() {
-      const { exportState, deleteOnFinish, atOnce } = this.state;
+      const {
+        exportState,
+        actionOnDuplicate,
+        deleteOnFinish,
+        atOnce
+      } = this.state;
       /* eslint-disable react/jsx-props-no-spreading */
       // $FlowFixMe
       return (
         <WrappedComponent
           {...this.props}
           exportState={exportState}
+          actionOnDuplicate={actionOnDuplicate}
+          setActionOnDuplicate={this.setActionOnDuplicate}
           deleteOnFinish={deleteOnFinish}
+          toggleDOF={this.toggleDOF}
           atOnce={atOnce}
           atOnceChange={this.atOnceChange}
           processVideo={this.processVideo}
           cancelProcess={this.cancelProcess}
-          toggleDOF={this.toggleDOF}
         />
       );
     }

--- a/app/components/VideoExportPage.js
+++ b/app/components/VideoExportPage.js
@@ -17,7 +17,13 @@ import * as ExportListActions from '../actions/exportList';
 
 import VideoExport from './VideoExport';
 import ExportRecordType from '../reducers/types';
-import { EXP_WORKING } from '../constants/app';
+import {
+  EXP_WORKING,
+  DUPE_SKIP,
+  DUPE_INC,
+  DUPE_OVERWRITE,
+  DUPE_ADDID
+} from '../constants/app';
 import { ExportRecord } from '../utils/factories';
 import Checkbox from './Checkbox';
 import routes from '../constants/routes.json';
@@ -25,11 +31,17 @@ import routes from '../constants/routes.json';
 type Props = {
   actionList: Array<Airing>,
   exportList: Array<ExportRecordType>,
-  atOnceChange: (event: SyntheticEvent<HTMLInputElement>) => void,
   exportState: number,
+
   atOnce: number,
+  atOnceChange: (event: SyntheticEvent<HTMLInputElement>) => void,
+
+  actionOnDuplicate: string,
+  setActionOnDuplicate: (action: string) => void,
+
   deleteOnFinished: number,
   toggleDOF: () => void,
+
   cancelProcess: () => void,
   processVideo: () => void,
 
@@ -66,11 +78,13 @@ class VideoExportPage extends Component<Props, State> {
       exportList,
       exportState,
       atOnce,
-      deleteOnFinished,
       atOnceChange,
+      deleteOnFinished,
+      toggleDOF,
+      actionOnDuplicate,
+      setActionOnDuplicate,
       cancelProcess,
-      processVideo,
-      toggleDOF
+      processVideo
     } = this.props;
 
     if (!loaded) return <></>; //
@@ -99,14 +113,17 @@ class VideoExportPage extends Component<Props, State> {
           atOnceChange={atOnceChange}
           cancel={cancelProcess}
           process={processVideo}
-          toggle={toggleDOF}
+          toggleDOF={toggleDOF}
           deleteOnFinish={deleteOnFinished}
+          actionOnDuplicate={actionOnDuplicate}
+          setActionOnDuplicate={setActionOnDuplicate}
         />
         {exportList.map(rec => {
           return (
             <RecordingExport
               airing={rec.airing}
               key={`RecordingExport-${rec.airing.object_id}`}
+              actionOnDuplicate={actionOnDuplicate}
             />
           );
         })}
@@ -126,7 +143,9 @@ function ExportActions(prop) {
     atOnce,
     atOnceChange,
     deleteOnFinish,
-    toggle
+    toggleDOF,
+    actionOnDuplicate,
+    setActionOnDuplicate
   } = prop;
 
   if (state === EXP_WORKING) {
@@ -181,10 +200,34 @@ function ExportActions(prop) {
         <Col md="auto" className="pt-2">
           <Checkbox
             checked={deleteOnFinish}
-            handleChange={toggle}
+            handleChange={toggleDOF}
             label="Delete when finished?"
           />
         </Col>
+        <Col md="auto">
+          <InputGroup size="sm" className="pt-1">
+            <InputGroup.Prepend>
+              <InputGroup.Text title="More than 2 is probably silly, but YOLO!">
+                <span className="fa fa-info pr-2" />
+                On duplicate:
+              </InputGroup.Text>
+            </InputGroup.Prepend>
+            <Form.Control
+              as="select"
+              value={actionOnDuplicate}
+              aria-describedby="btnState"
+              onChange={setActionOnDuplicate}
+              title="More than 2 is probably silly, but YOLO!"
+            >
+              <option value={DUPE_INC}>{DUPE_INC.toLowerCase()}</option>
+              <option value={DUPE_OVERWRITE}>
+                {DUPE_OVERWRITE.toLowerCase()}
+              </option>
+              <option value={DUPE_ADDID}>add id</option>
+              <option value={DUPE_SKIP}>{DUPE_SKIP.toLowerCase()}</option>
+            </Form.Control>
+          </InputGroup>
+        </Col>{' '}
       </Row>
     </Alert>
   );

--- a/app/constants/app.js
+++ b/app/constants/app.js
@@ -20,7 +20,7 @@ export const EXP_DELETE = 6;
 
 export const DUPE_OVERWRITE = 'OVERWRITE';
 export const DUPE_SKIP = 'SKIP';
-export const DUPE_INC = 'INC';
+export const DUPE_INC = 'INCREMENT';
 export const DUPE_ADDID = 'ADDID';
 
 export const beginTimemark = '00:00 / 00:00';

--- a/app/constants/app.js
+++ b/app/constants/app.js
@@ -18,6 +18,11 @@ export const EXP_CANCEL = 4;
 export const EXP_FAIL = 5;
 export const EXP_DELETE = 6;
 
+export const DUPE_OVERWRITE = 'OVERWRITE';
+export const DUPE_SKIP = 'SKIP';
+export const DUPE_INC = 'INC';
+export const DUPE_ADDID = 'ADDID';
+
 export const beginTimemark = '00:00 / 00:00';
 
 export const EMPTY_SEARCHALERT: SearchAlert = {

--- a/app/constants/routes.json
+++ b/app/constants/routes.json
@@ -16,6 +16,7 @@
   "GENSETTINGS": "/settings/general",
   "FILENAMETPLs": "/settings/filename-templates",
   "ADVSETTINGS": "/settings/advanced",
+  "EXPSETTINGS": "/settings/export",
   "EXPORT": "/export",
   "DELETE": "/delete",
   "SELECTED": "/selected",

--- a/app/containers/SettingsPage.js
+++ b/app/containers/SettingsPage.js
@@ -15,6 +15,7 @@ import routes from '../constants/routes.json';
 import SettingsGeneral from '../components/SettingsGeneral';
 import SettingsAdvanced from '../components/SettingsAdvanced';
 import SettingsNaming from '../components/SettingsNaming';
+import SettingsExport from '../components/SettingsExport';
 
 type Props = { location: any };
 
@@ -31,6 +32,9 @@ class SettingsPage extends Component<Props> {
         break;
       case routes.FILENAMETPLs:
         content = <SettingsNaming />;
+        break;
+      case routes.EXPSETTINGS:
+        content = <SettingsExport />;
         break;
       default:
     }
@@ -49,8 +53,26 @@ class SettingsPage extends Component<Props> {
                     activeClassName="active"
                     to={routes.GENSETTINGS}
                   >
-                    <Button size="sm" variant="light" as="button" title="Home">
+                    <Button
+                      size="sm"
+                      variant="light"
+                      as="button"
+                      title="General"
+                    >
                       General
+                    </Button>
+                  </LinkContainer>
+                  <LinkContainer
+                    activeClassName="active"
+                    to={routes.EXPSETTINGS}
+                  >
+                    <Button
+                      size="sm"
+                      variant="light"
+                      as="button"
+                      title="Export"
+                    >
+                      Export
                     </Button>
                   </LinkContainer>
                   <LinkContainer
@@ -61,7 +83,7 @@ class SettingsPage extends Component<Props> {
                       size="sm"
                       variant="light"
                       as="button"
-                      title="Watch Live"
+                      title="Naming"
                     >
                       Naming
                     </Button>
@@ -70,7 +92,12 @@ class SettingsPage extends Component<Props> {
                     activeClassName="active"
                     to={routes.ADVSETTINGS}
                   >
-                    <Button size="sm" variant="light" as="button" title="Home">
+                    <Button
+                      size="sm"
+                      variant="light"
+                      as="button"
+                      title="Advanced"
+                    >
                       Advanced
                     </Button>
                   </LinkContainer>

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -1,6 +1,12 @@
 import os from 'os';
 import fs from 'fs';
 import path from 'path';
+import {
+  DUPE_ADDID,
+  DUPE_INC,
+  DUPE_OVERWRITE,
+  DUPE_SKIP
+} from '../constants/app';
 
 const electron = require('electron');
 
@@ -51,10 +57,20 @@ export type ConfigType = {
   eventTemplate: string,
   programTemplate: string,
 
+  // TODO: enum
+  actionOnDuplicate: string,
+
   // TODO: these are residual from Settings b/c I haven't done the config properly
   saveState?: number,
   saveData: Array<string>
 };
+
+export const VALID_DUPE_ACTIONS = [
+  DUPE_ADDID,
+  DUPE_INC,
+  DUPE_OVERWRITE,
+  DUPE_SKIP
+];
 
 export const defaultConfig: ConfigType = {
   autoRebuild: true,
@@ -80,6 +96,8 @@ export const defaultConfig: ConfigType = {
   movieTemplate: 'tablo-tools',
   eventTemplate: 'tablo-tools',
   programTemplate: 'tablo-tools',
+
+  actionOnDuplicate: DUPE_ADDID,
 
   saveData: []
 };


### PR DESCRIPTION
- Settings -> Export menu allowing:
   - Incremental naming (default)
   - Overwrite
   - Add object_id
   - Skip
- More specific Export File name displays based on deduping method
- Update the "Export" action button to change color/help text if we see the exported file

- Add ffmpeg info to Details popup when it exists
- Fix: Make sure directory opened is not the parent directory
- Fixed long time wrong date/time format