### PR TITLE
Fix autorebuild ui, suppress flash

### DIFF
--- a/src/renderer/components/DurationPicker.tsx
+++ b/src/renderer/components/DurationPicker.tsx
@@ -17,7 +17,7 @@ export default class DurationPicker extends Component<Props, State> {
     this.state = {
       hours: 0,
       minutes: 30,
-      disabled: false,
+      disabled: props.disabled,
     };
     this.setMinutes = this.setMinutes.bind(this);
     this.setHours = this.setHours.bind(this);
@@ -89,6 +89,7 @@ export default class DurationPicker extends Component<Props, State> {
 
   render() {
     const { hours, minutes, disabled } = this.state;
+    console.log('hours', hours, 'minutes', minutes, 'disabled', disabled);
     return (
       <div className="pl-4 smaller">
         <div className="d-flex flex-row">

--- a/src/renderer/components/Flash.tsx
+++ b/src/renderer/components/Flash.tsx
@@ -23,6 +23,10 @@ class Flash extends Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     const { message } = this.props;
+    if (!message.message) {
+      console.warn('Flash: no message received');
+      return;
+    }
 
     if (prevProps.message !== message) {
       this.receive();

--- a/src/renderer/components/SettingsGeneral.tsx
+++ b/src/renderer/components/SettingsGeneral.tsx
@@ -101,7 +101,7 @@ class SettingsGeneral extends Component<SettingsGeneralProps, ConfigType> {
 
     this.setState(item);
     setConfigItem(item);
-    sendFlash(message);
+    if (!message) sendFlash(message);
   };
 
   toggleAutoRebuild = () => {
@@ -120,8 +120,12 @@ class SettingsGeneral extends Component<SettingsGeneralProps, ConfigType> {
   };
 
   setAutoRebuildMinutes = (minutes: number | null) => {
+    const { autoRebuild } = this.state;
     if (!minutes) return;
-    const message = `DB Rebuild will happen every ${minutes} minutes`;
+    let message = '';
+    if (autoRebuild)
+      message = `DB Rebuild will happen every ${minutes} minutes`;
+
     this.saveConfigItem(
       {
         autoRebuildMinutes: minutes,


### PR DESCRIPTION
Fixes the autorebuild UI duration fields being enabled when it was disabled. Also fixes the Flash firing when it shouldn't, but with warning logs