### PR TITLE
Make autoRebuild more useful #48

### DIFF
--- a/@types/global.d.ts
+++ b/@types/global.d.ts
@@ -9,7 +9,7 @@ declare var navigator: Navigator;
 
 declare var discoveredDevices: Array<any>;
 
-declare var CONNECTED: boolean;
+declare var isConnected: boolean;
 
 declare var EXPORTING: boolean;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
         "@types/enzyme": "^3.10.9",
         "@types/enzyme-adapter-react-16": "^1.0.6",
         "@types/fluent-ffmpeg": "^2.1.21",
+        "@types/glob": "^8.1.0",
         "@types/history": "4.7.9",
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/inquirer": "^9.0.3",
@@ -2986,6 +2987,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -3149,8 +3160,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -23021,6 +23031,16 @@
         "@types/node": "*"
       }
     },
+    "@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -23184,8 +23204,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/ms": {
       "version": "0.7.31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "check-disk-space": "^3.3.1",
         "compare-versions": "^5.0.3",
         "connected-react-router": "^6.9.2",
+        "croner": "^6.0.3",
         "date-fns": "^2.8.1",
         "debug": "^4.3.4",
         "deep-object-diff": "^1.1.9",
@@ -6111,6 +6112,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/croner": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-6.0.3.tgz",
+      "integrity": "sha512-Go+s9AaI+MeZUDJ6Kp7OYXCbM3svJ0qZ3IpkGoPetZLnP5wpX8MBTEiJOTYDFokP0Ph85GFZEUTBL9fo1e4DtQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -25536,6 +25545,11 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "croner": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-6.0.3.tgz",
+      "integrity": "sha512-Go+s9AaI+MeZUDJ6Kp7OYXCbM3svJ0qZ3IpkGoPetZLnP5wpX8MBTEiJOTYDFokP0Ph85GFZEUTBL9fo1e4DtQ=="
     },
     "cross-env": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "@types/enzyme": "^3.10.9",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/fluent-ffmpeg": "^2.1.21",
+    "@types/glob": "^8.1.0",
     "@types/history": "4.7.9",
     "@types/hoist-non-react-statics": "^3.3.0",
     "@types/inquirer": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -280,6 +280,7 @@
     "check-disk-space": "^3.3.1",
     "compare-versions": "^5.0.3",
     "connected-react-router": "^6.9.2",
+    "croner": "^6.0.3",
     "date-fns": "^2.8.1",
     "debug": "^4.3.4",
     "deep-object-diff": "^1.1.9",

--- a/src/main/pre_Tablo.ts
+++ b/src/main/pre_Tablo.ts
@@ -58,11 +58,11 @@ ipcMain.on('tablo-setCurrentDevice', async (event: any, device: any) => {
   }
 });
 
-ipcMain.on('tablo-CONNECTED', async (event: any) => {
+ipcMain.on('tablo-isConnected', async (event: any) => {
   try {
-    event.returnValue = global.CONNECTED;
+    event.returnValue = global.isConnected;
   } catch (e) {
-    console.error('tablo-CONNECTED', e);
+    console.error('tablo-isConnected', e);
     event.returnValue = false;
   }
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -106,7 +106,7 @@ contextBridge.exposeInMainWorld('Tablo', {
   checkConnection: () => ipcRenderer.sendSync('tablo-checkConnection'),
   comskipAvailable: () => ipcRenderer.sendSync('tablo-comskipAvailable'),
   hasDevice: () => ipcRenderer.sendSync('tablo-has-device'),
-  CONNECTED: () => ipcRenderer.sendSync('tablo-CONNECTED'),
+  isConnected: () => ipcRenderer.sendSync('tablo-isConnected'),
   device: () => ipcRenderer.sendSync('tablo-device'),
   discoveredDevices: () => ipcRenderer.sendSync('tablo-discoveredDevices'),
   getRecordingsCount: () => ipcRenderer.sendSync('tablo-getRecordingsCount'),

--- a/src/main/utils/Tablo.ts
+++ b/src/main/utils/Tablo.ts
@@ -156,7 +156,7 @@ export async function checkConnection(): Promise<boolean> {
 
   return new Promise((resolve) => {
     client.on('close', () => {
-      global.CONNECTED = status;
+      global.isConnected = status;
       resolve(status);
     });
   });
@@ -165,7 +165,7 @@ export async function checkConnection(): Promise<boolean> {
 export const comskipAvailable = (): boolean => {
   const currentDevice: any = store.get('CurrentDevice');
 
-  if (!global.CONNECTED) return false;
+  if (!global.isConnected) return false;
   if (!currentDevice.server_version) return false;
   const testVersion = currentDevice.server_version.match(/[\d.]*/)[0];
   const supportedVersion = '2.2.26';
@@ -191,7 +191,7 @@ export const comskipAvailable = (): boolean => {
 export async function setupApi(): Promise<void> {
   debug('Calling setupApi');
   globalThis.Api = new Tablo();
-  global.CONNECTED = false;
+  global.isConnected = false;
   debug('Calling discover');
   await discover();
   debug('Discover finished');

--- a/src/renderer/components/Build.tsx
+++ b/src/renderer/components/Build.tsx
@@ -92,7 +92,7 @@ class Build extends Component<BuildProps, State> {
       return;
     }
 
-    if (!window.Tablo.CONNECTED()) {
+    if (!window.Tablo.isConnected()) {
       console.log('Not connected, not bulding...');
       return;
     }

--- a/src/renderer/components/Build.tsx
+++ b/src/renderer/components/Build.tsx
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux';
 import { writeToFile } from '../utils/utils';
 import getConfig from '../utils/config';
 
-import { dbCreatedKey, recDbCreated } from '../utils/db';
+import { dbCreatedKey } from '../utils/db';
 
 import * as BuildActions from '../store/build';
 import { DbSliceState } from '../store/build';
@@ -49,35 +49,9 @@ class Build extends Component<BuildProps, State> {
     this.build = this.build.bind(this);
   }
 
-  async componentDidMount() {
-    let created = recDbCreated();
-
-    // TODO: some const export?
-    if (!created) {
-      let i = 0;
-
-      const autoBuild = async () => {
-        created = recDbCreated();
-
-        if (!window.Tablo.device() && !created) {
-          if (i > 0) return;
-          i += 1;
-          setTimeout(autoBuild, 5000);
-        }
-
-        if (window.Tablo.device() && !created) this.build();
-      };
-
-      autoBuild();
-    }
-  }
-
   componentDidUpdate(prevProps: BuildProps) {
     const { progress } = this.props;
-    if (
-      prevProps.progress.loading !== progress.loading &&
-      progress.loading === STATE_START
-    ) {
+    if (progress.loading === STATE_START) {
       this.build();
     }
   }
@@ -88,17 +62,18 @@ class Build extends Component<BuildProps, State> {
     if (!window.Tablo.device()) return;
 
     if (this.building) {
-      console.log('trying to double build');
+      console.warn('trying to double build');
       return;
     }
+    this.building = true;
 
     if (!window.Tablo.isConnected()) {
-      console.log('Not connected, not bulding...');
+      console.warn('Not connected, not bulding...');
       return;
     }
 
     if (global.EXPORTING) {
-      console.log('Exporting, not bulding...');
+      console.warn('Exporting, not building...');
       return;
     }
 

--- a/src/renderer/components/DbStats.tsx
+++ b/src/renderer/components/DbStats.tsx
@@ -35,7 +35,6 @@ export default class DbStats extends Component<Props, State> {
   }
 
   async refresh() {
-    // const { RecDb } = global;
     const recTotal = window.db.countAsync('RecDb', {});
 
     /** Watched * */

--- a/src/renderer/components/DbStatus.tsx
+++ b/src/renderer/components/DbStatus.tsx
@@ -40,6 +40,7 @@ class DbStatus extends Component<DbStatusProps, State> {
 
   job: Cron;
 
+  // eslint-disable-next-line
   rerender: Cron;
 
   constructor(props: DbStatusProps) {
@@ -54,9 +55,12 @@ class DbStatus extends Component<DbStatusProps, State> {
 
     // cron syntax that runs 2 minutes and 32 minutes after the hour
     this.job = Cron('2,32 * * * *', { maxRuns: 1 });
+
+    // eslint-disable-next-line
     this.rerender = Cron('* * * * *', {}, () => {
       this.updateTime();
     });
+
     this.forceBuild = this.forceBuild.bind(this);
   }
 
@@ -72,11 +76,7 @@ class DbStatus extends Component<DbStatusProps, State> {
       this.job.trigger();
     }
 
-    if (!this.rerender) {
-      this.rerender = Cron('* * * * *', {}, () => {
-        this.updateTime();
-      });
-    }
+    this.updateTime();
     this.psToken = PubSub.subscribe('DB_CHANGE', () => this.updateTime());
   }
 

--- a/src/renderer/components/DbStatus.tsx
+++ b/src/renderer/components/DbStatus.tsx
@@ -124,7 +124,7 @@ class DbStatus extends Component<DbStatusProps, State> {
     //   this.autoRebuildInterval
     // );
     if ((autoRebuild && diff > this.autoRebuildInterval) || forceBuild) {
-      if (window.Tablo.CONNECTED()) startBuild();
+      if (window.Tablo.isConnected()) startBuild();
       clearInterval(this.timer);
       this.timer = setInterval(this.checkAge, this.rebuildPollInterval);
     }

--- a/src/renderer/components/DbStatus.tsx
+++ b/src/renderer/components/DbStatus.tsx
@@ -103,7 +103,7 @@ class DbStatus extends Component<DbStatusProps, State> {
 
   componentDidUpdate(prevProps: DbStatusProps) {
     const { config } = this.props;
-    console.log(config);
+
     if (config.autoRebuild !== prevProps.config.autoRebuild) {
       if (config.autoRebuild) {
         this.buildIfOutdated();

--- a/src/renderer/components/DbStatus.tsx
+++ b/src/renderer/components/DbStatus.tsx
@@ -115,7 +115,8 @@ class DbStatus extends Component<DbStatusProps, State> {
   }
 
   componentWillUnmount(): void {
-    // this.job.stop();
+    this.job.stop();
+    this.rerender.stop();
     PubSub.unsubscribe(this.psToken);
   }
 

--- a/src/renderer/components/DbStatus.tsx
+++ b/src/renderer/components/DbStatus.tsx
@@ -190,7 +190,7 @@ class DbStatus extends Component<DbStatusProps, State> {
                 cursor: 'pointer',
               }}
               onClick={this.forceBuild}
-              onKeyDown={this.forceBuild}
+              onKeyDown={() => {}}
               role="button"
               tabIndex={0}
               className="pl-0 btn btn-xs smaller pr-0"

--- a/src/renderer/components/Discovery.tsx
+++ b/src/renderer/components/Discovery.tsx
@@ -81,7 +81,7 @@ function DiscoveryStatus(prop: Record<string, any>) {
 function DiscoveryTitle(prop: Record<string, any>) {
   const { device, localDiscover, state } = prop;
   let checked;
-  if (window.Tablo.CONNECTED()) {
+  if (window.Tablo.isConnected()) {
     if (state === STATE_MULTI) return <></>;
     checked = device.inserted ? new Date(device.inserted) : '';
     return (

--- a/src/renderer/components/DurationPicker.tsx
+++ b/src/renderer/components/DurationPicker.tsx
@@ -89,7 +89,7 @@ export default class DurationPicker extends Component<Props, State> {
 
   render() {
     const { hours, minutes, disabled } = this.state;
-    console.log('hours', hours, 'minutes', minutes, 'disabled', disabled);
+
     return (
       <div className="pl-4 smaller">
         <div className="d-flex flex-row">

--- a/src/renderer/components/ServerInfoTable.tsx
+++ b/src/renderer/components/ServerInfoTable.tsx
@@ -35,7 +35,7 @@ export default class ServerInfoTable extends Component<Props, State> {
   }
 
   refresh = async () => {
-    if (window.Tablo.CONNECTED()) {
+    if (window.Tablo.isConnected()) {
       try {
         const serverInfo = window.Tablo.getServerInfo();
         this.setState({

--- a/src/renderer/components/SettingsGeneral.tsx
+++ b/src/renderer/components/SettingsGeneral.tsx
@@ -6,15 +6,19 @@ import { bindActionCreators } from 'redux';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import * as FlashActions from '../store/flash';
+import * as ConfigActions from '../store/config';
 import type { FlashRecordType } from '../constants/types';
 import { isValidIp } from '../utils/utils';
 import { discover } from '../utils/Tablo';
 // these next 2 are gross and from not cleaning up the main/render split
-import getConfig, { getPath, setConfigItem } from '../utils/config';
+import getConfig, {
+  getPath,
+  setConfigItem as setConfigItemFs,
+} from '../utils/config';
 import { ConfigType } from '../constants/types_config';
 
 import Checkbox, { CHECKBOX_OFF, CHECKBOX_ON } from './Checkbox';
-import DurationPicker from './DurationPicker';
+// import DurationPicker from './DurationPicker';
 import Directory from './Directory';
 
 type OwnProps = Record<string, never>;
@@ -22,6 +26,7 @@ type StateProps = Record<string, never>;
 
 type DispatchProps = {
   sendFlash: (message: FlashRecordType) => void;
+  setConfigItem: (item: Record<string, any>) => void;
 };
 
 type SettingsGeneralProps = OwnProps & StateProps & DispatchProps;
@@ -97,9 +102,10 @@ class SettingsGeneral extends Component<SettingsGeneralProps, ConfigType> {
 
   /** This does the real work... */
   saveConfigItem = (item: any, message: FlashRecordType) => {
-    const { sendFlash } = this.props;
+    const { sendFlash, setConfigItem } = this.props;
 
     this.setState(item);
+    setConfigItemFs(item);
     setConfigItem(item);
     if (!message) sendFlash(message);
   };
@@ -323,7 +329,7 @@ class SettingsGeneral extends Component<SettingsGeneralProps, ConfigType> {
   render() {
     const {
       autoRebuild,
-      autoRebuildMinutes,
+      // autoRebuildMinutes,
       autoUpdate,
       notifyBeta,
       allowErrorReport,
@@ -351,11 +357,11 @@ class SettingsGeneral extends Component<SettingsGeneralProps, ConfigType> {
               checked={autoRebuild ? CHECKBOX_ON : CHECKBOX_OFF}
               label="Enable automatically rebuilding local database?"
             />
-            <DurationPicker
+            {/* <DurationPicker
               value={autoRebuildMinutes}
               updateValue={this.setAutoRebuildMinutes}
               disabled={!autoRebuild}
-            />
+            /> */}
           </div>
         </div>
         <Row className="mt-3">
@@ -439,7 +445,7 @@ class SettingsGeneral extends Component<SettingsGeneralProps, ConfigType> {
 }
 
 const mapDispatchToProps = (dispatch: any) => {
-  return bindActionCreators(FlashActions, dispatch);
+  return bindActionCreators({ ...FlashActions, ...ConfigActions }, dispatch);
 };
 
 export default connect<StateProps, DispatchProps, OwnProps>(

--- a/src/renderer/components/SettingsGeneral.tsx
+++ b/src/renderer/components/SettingsGeneral.tsx
@@ -349,7 +349,7 @@ class SettingsGeneral extends Component<SettingsGeneralProps, ConfigType> {
     }
 
     return (
-      <div>
+      <div className="pl-1">
         <div className="mt-3">
           <div>
             <Checkbox
@@ -357,6 +357,14 @@ class SettingsGeneral extends Component<SettingsGeneralProps, ConfigType> {
               checked={autoRebuild ? CHECKBOX_ON : CHECKBOX_OFF}
               label="Enable automatically rebuilding local database?"
             />
+            <div className="pl-4 smaller">
+              When enabled, the local recording database will automatically
+              reload:
+              <ul>
+                <li>On startup if outdated</li>
+                <li>2 and 32 minutes after the hour.</li>
+              </ul>
+            </div>
             {/* <DurationPicker
               value={autoRebuildMinutes}
               updateValue={this.setAutoRebuildMinutes}

--- a/src/renderer/rootReducer.ts
+++ b/src/renderer/rootReducer.ts
@@ -7,6 +7,7 @@ import { History } from 'history';
 
 // import { sendFlash } from './reducers/flash';
 import buildReducer from './store/build';
+import configReducer from './store/config';
 import flashReducer from './store/flash';
 import searchReducer from './store/search';
 import actionListReducer from './store/actionList';
@@ -20,5 +21,6 @@ export default function createRootReducer(history: History) {
     search: searchReducer,
     flash: flashReducer,
     build: buildReducer,
+    config: configReducer,
   });
 }

--- a/src/renderer/store/build.ts
+++ b/src/renderer/store/build.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { STATE_START, STATE_LOADING } from '../constants/app';
+import { STATE_START, STATE_WAITING } from '../constants/app';
 
 export type DbSliceState = {
   loading?: number;
@@ -10,20 +10,20 @@ export type DbSliceState = {
   recCount?: number;
 };
 
+const initialState = {
+  loading: STATE_WAITING,
+  log: [],
+  airingInc: 0,
+  airingMax: 1,
+  recCount: 0,
+} as DbSliceState;
+
 const slice = createSlice({
   name: 'build',
-
-  initialState: {
-    loading: 0,
-    log: [],
-    airingInc: 0,
-    airingMax: 1,
-    recCount: 0,
-  } as DbSliceState,
-
+  initialState,
   reducers: {
-    startBuild: (state) => {
-      if (state.loading !== STATE_LOADING) state.loading = STATE_START;
+    startBuild: () => {
+      return { ...initialState, loading: STATE_START };
     },
     updateProgress: (state, action: PayloadAction<DbSliceState>) => {
       const { payload } = action;
@@ -32,6 +32,7 @@ const slice = createSlice({
       if (payload.airingInc !== undefined) state.airingInc = payload.airingInc;
       if (payload.airingMax !== undefined) state.airingMax = payload.airingMax;
       if (payload.recCount !== undefined) state.recCount = payload.recCount;
+      return state;
     },
   },
 });

--- a/src/renderer/store/config.ts
+++ b/src/renderer/store/config.ts
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import getConfig from 'renderer/utils/config';
+
+const initialState = getConfig();
+
+const slice = createSlice({
+  name: 'config',
+
+  initialState,
+
+  reducers: {
+    setConfig: (_, action: PayloadAction<any>) => {
+      return action.payload;
+    },
+
+    setConfigItem: (_, action: PayloadAction<any>) => {
+      return { ...initialState, ...action.payload };
+    },
+  },
+});
+
+export const { setConfig, setConfigItem } = slice.actions;
+
+export default slice.reducer;


### PR DESCRIPTION
Enabling autoRebuild will now cause an outdated db to be reloaded on startup as well as reloading at 2 and 32 minutes after the hour. Fixes #48 